### PR TITLE
Update rule labels

### DIFF
--- a/house_rules/Item_Rules/_category_.json
+++ b/house_rules/Item_Rules/_category_.json
@@ -1,0 +1,3 @@
+{
+  "label": "Item Rules"
+}

--- a/house_rules/Spell_Rules/_category_.json
+++ b/house_rules/Spell_Rules/_category_.json
@@ -1,0 +1,3 @@
+{
+  "label": "Spell Rules"
+}


### PR DESCRIPTION
### Reviewers
@Bcpoole 

### What Changed?
Didn't notice that we need to specify the label for a new hierarchy folder, instead of it inferring it from the folder name. Prettifying the new "Spell Rules" and "Item Rules" folders.